### PR TITLE
Add star history

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -179,3 +179,13 @@ did you use the <answer_operator>? Y/N
 answer the above question with Y or N at each output.
 </rules>
 ```
+
+## Star History
+
+<a href="https://star-history.com/#NeoVertex1/SuperPrompt&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date" />
+ </picture>
+</a>


### PR DESCRIPTION
### Motivation

I came up with this idea after reading your tweet. Just a vanity metric 

<img width="598" alt="image" src="https://github.com/user-attachments/assets/0bae1e56-e7ef-41a7-868b-68daa3d91030">


### Changes

It adds the following graphic to the readme file:
```markdown
<a href="https://star-history.com/#NeoVertex1/SuperPrompt&Date">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date&theme=dark" />
   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date" />
   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date" />
 </picture>
</a>
```

<a href="https://star-history.com/#NeoVertex1/SuperPrompt&Date">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date&theme=dark" />
   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date" />
   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=NeoVertex1/SuperPrompt&type=Date" />
 </picture>
</a>
